### PR TITLE
fix: SecurityConfiguration csrf 적용 및 변수명 단축

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/configuration/SecurityConfiguration.java
+++ b/perfume-api/src/main/java/io/perfume/api/configuration/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -16,22 +17,24 @@ import java.util.List;
 public class SecurityConfiguration {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, WhiteListConfiguration whiteListConfiguration) throws Exception {
-        http
-                .cors(c -> c.configurationSource(corsConfigurationSource(whiteListConfiguration.getCors())));
+    public SecurityFilterChain filterChain(HttpSecurity http, WhiteListConfiguration whiteListConfig) throws Exception {
+        http.csrf(CsrfConfigurer::disable);
+        http.cors(c -> c.configurationSource(corsConfigurationSource(whiteListConfig.getCors())));
 
+        http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests.anyRequest().permitAll());
         return http.build();
     }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource(List<String> whitelistCors) {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(whitelistCors);
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(whitelistCors);
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
+        source.registerCorsConfiguration("/**", config);
 
         return source;
     }


### PR DESCRIPTION
## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- 모든 API 요청시 403에러 뜨는 이유는 csrf가 disable되지 않아서였으므로 disable해둡니다.
- 변수명도 가독성 좋게 단축했습니다.

## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
-

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
