### PR TITLE
FIX: UserNotFoundException 클래스 이동

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/sample/application/exception/SampleNotFoundException.java
+++ b/perfume-api/src/main/java/io/perfume/api/sample/application/exception/SampleNotFoundException.java
@@ -1,0 +1,11 @@
+package io.perfume.api.sample.application.exception;
+
+import io.perfume.api.base.CustomHttpException;
+import io.perfume.api.base.LogLevel;
+import org.springframework.http.HttpStatus;
+
+public class SampleNotFoundException extends CustomHttpException {
+    public SampleNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "sample does not exist", "sample does not exist", LogLevel.WARN);
+    }
+}

--- a/perfume-api/src/main/java/io/perfume/api/sample/application/exception/UserNotFoundException.java
+++ b/perfume-api/src/main/java/io/perfume/api/sample/application/exception/UserNotFoundException.java
@@ -1,4 +1,0 @@
-package io.perfume.api.sample.application.exception;
-
-public class UserNotFoundException extends RuntimeException {
-}

--- a/perfume-api/src/main/java/io/perfume/api/sample/application/service/SampleService.java
+++ b/perfume-api/src/main/java/io/perfume/api/sample/application/service/SampleService.java
@@ -1,6 +1,6 @@
 package io.perfume.api.sample.application.service;
 
-import io.perfume.api.sample.application.exception.UserNotFoundException;
+import io.perfume.api.sample.application.exception.SampleNotFoundException;
 import io.perfume.api.sample.application.port.in.CreateSampleUseCase;
 import io.perfume.api.sample.application.port.in.DeleteSampleUseCase;
 import io.perfume.api.sample.application.port.in.GetSampleUseCase;
@@ -32,7 +32,7 @@ public class SampleService implements CreateSampleUseCase, DeleteSampleUseCase,
   @Override
   @Transactional(readOnly = true)
   public SampleResult getSample(Long id) {
-    Sample sample = sampleQueryRepository.findById(id).orElseThrow(UserNotFoundException::new);
+    Sample sample = sampleQueryRepository.findById(id).orElseThrow(SampleNotFoundException::new);
 
     return toDto(sample);
   }
@@ -48,7 +48,7 @@ public class SampleService implements CreateSampleUseCase, DeleteSampleUseCase,
   @Override
   @Transactional
   public SampleResult updateSample(Long id, String name) {
-    Sample sample = sampleQueryRepository.findById(id).orElseThrow(UserNotFoundException::new);
+    Sample sample = sampleQueryRepository.findById(id).orElseThrow(SampleNotFoundException::new);
 
     sample.changeName(name);
 

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/exception/UserNotFoundException.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package io.perfume.api.user.adapter.out.persistence.exception;
+
+import io.perfume.api.base.CustomHttpException;
+import io.perfume.api.base.LogLevel;
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends CustomHttpException {
+    public UserNotFoundException(Long userId) {
+        super(HttpStatus.NOT_FOUND, "cannot find user.", "cannot find user. userId : " + userId, LogLevel.WARN);
+    }
+}

--- a/perfume-api/src/test/java/io/perfume/api/sample/application/SampleServiceTest.java
+++ b/perfume-api/src/test/java/io/perfume/api/sample/application/SampleServiceTest.java
@@ -3,7 +3,7 @@ package io.perfume.api.sample.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.perfume.api.sample.application.exception.UserNotFoundException;
+import io.perfume.api.sample.application.exception.SampleNotFoundException;
 import io.perfume.api.sample.application.port.in.dto.SampleResult;
 import io.perfume.api.sample.application.service.SampleService;
 import io.perfume.api.sample.domain.Sample;
@@ -84,6 +84,6 @@ class SampleServiceTest {
   @Test
   void testUpdateSampleIfNotExists() {
     // when & then
-    assertThrows(UserNotFoundException.class, () -> sampleService.updateSample(1L, "sample 1"));
+    assertThrows(SampleNotFoundException.class, () -> sampleService.updateSample(1L, "sample 1"));
   }
 }


### PR DESCRIPTION
## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- https://github.com/read-a-perfume/backend/pull/101 반영 전 필요한 PR 입니다.

## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
- 기존 sample 패키지 내의 UserNotFoundException 을 user 패키지로 이동시켰습니다.
- sample 패키지에는 SampleNotFoundException이 있도록 변경합니다.
- CustomHttpException을 상속받도록 하였는데, 에러 메시지가 적절한지 확인이 필요합니다!

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
