### PR TITLE
[RDPF - 64] 회원탈퇴 useCase 작성

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/auth/application/service/AuthenticationTokenService.java
+++ b/perfume-api/src/main/java/io/perfume/api/auth/application/service/AuthenticationTokenService.java
@@ -26,6 +26,7 @@ public class AuthenticationTokenService {
   public String createAccessToken(Long userId, LocalDateTime now) {
     return jsonWebTokenGenerator.create(
         ACCESS_TOKEN_NAME,
+        // TODO 'userId'같은 상수값이 사용할 때 마다 정의해서 사용중, 상수값을 모아서 관리하고싶음
         Map.of("userId", userId, "roles", List.of("ROLE_USER")),
         jwtProperties.accessTokenValidityInSeconds(),
         now);

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -4,6 +4,7 @@ import io.perfume.api.common.auth.UserPrincipal;
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
 import io.perfume.api.user.application.port.in.LeaveUserUseCase;
 import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
+import io.perfume.api.user.domain.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -42,8 +43,8 @@ public class UsersSupportController {
     }
 
     @DeleteMapping("/user")
-    public ResponseEntity leaveUser(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        leaveUserUseCase.leave(userPrincipal.getUser().getId());
+    public ResponseEntity leaveUser(@AuthenticationPrincipal User user) {
+        leaveUserUseCase.leave(Long.parseLong(user.getUsername()));
         return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/users")
+@RequestMapping("/v1/user")
 public class UsersSupportController {
 
     private final FindEncryptedUsernameUseCase findEncryptedUsernameUseCase;

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -1,22 +1,24 @@
 package io.perfume.api.user.adapter.in.http;
 
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
-import io.perfume.api.user.application.port.in.FindUserUseCase;
+import io.perfume.api.user.application.port.in.LeaveUserUseCase;
 import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1")
+@RequestMapping("/v1/users")
 public class UsersSupportController {
 
     private final FindEncryptedUsernameUseCase findEncryptedUsernameUseCase;
     private final SendResetPasswordMailUseCase resetPasswordUserCase;
 
+    private final LeaveUserUseCase leaveUserUseCase;
     /**
      * TODO OAUTH 가입자의 경우 uesrname도 같이 넣는 흐름이 이상하다.
      */
@@ -37,4 +39,9 @@ public class UsersSupportController {
         return ResponseEntity.ok(encryptedUsername);
     }
 
+    @DeleteMapping
+    public ResponseEntity leaveUser(@RequestHeader(name = "Authorization") String accessToken) {
+        leaveUserUseCase.leave(accessToken);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+    }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -4,13 +4,13 @@ import io.perfume.api.common.auth.UserPrincipal;
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
 import io.perfume.api.user.application.port.in.LeaveUserUseCase;
 import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
-import io.perfume.api.user.domain.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -1,5 +1,6 @@
 package io.perfume.api.user.adapter.in.http;
 
+import io.perfume.api.common.auth.UserPrincipal;
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
 import io.perfume.api.user.application.port.in.LeaveUserUseCase;
 import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,8 +42,8 @@ public class UsersSupportController {
     }
 
     @DeleteMapping("/user")
-    public ResponseEntity leaveUser(@RequestHeader(name = "Authorization") String accessToken) {
-        leaveUserUseCase.leave(accessToken);
+    public ResponseEntity leaveUser(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        leaveUserUseCase.leave(userPrincipal.getUser().getId());
         return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/user")
+@RequestMapping("/v1")
 public class UsersSupportController {
 
     private final FindEncryptedUsernameUseCase findEncryptedUsernameUseCase;
@@ -39,7 +39,7 @@ public class UsersSupportController {
         return ResponseEntity.ok(encryptedUsername);
     }
 
-    @DeleteMapping
+    @DeleteMapping("/user")
     public ResponseEntity leaveUser(@RequestHeader(name = "Authorization") String accessToken) {
         leaveUserUseCase.leave(accessToken);
         return ResponseEntity.status(HttpStatus.ACCEPTED).build();

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/exception/UserNotFoundException.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/exception/UserNotFoundException.java
@@ -7,5 +7,5 @@ import org.springframework.http.HttpStatus;
 public class UserNotFoundException extends CustomHttpException {
     public UserNotFoundException(Long userId) {
         super(HttpStatus.NOT_FOUND, "cannot find user.", "cannot find user. userId : " + userId, LogLevel.WARN);
-    }
+    }  
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/application/exception/FailedLeaveException.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/exception/FailedLeaveException.java
@@ -1,0 +1,12 @@
+package io.perfume.api.user.application.exception;
+
+import io.perfume.api.base.CustomHttpException;
+import io.perfume.api.base.LogLevel;
+import org.springframework.http.HttpStatus;
+
+public class FailedLeaveException extends CustomHttpException {
+    public FailedLeaveException(String message, String logMessage)
+    {
+        super(HttpStatus.UNAUTHORIZED, message, logMessage, LogLevel.WARN);
+    }
+}

--- a/perfume-api/src/main/java/io/perfume/api/user/application/exception/FailedToLeaveException.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/exception/FailedToLeaveException.java
@@ -4,8 +4,8 @@ import io.perfume.api.base.CustomHttpException;
 import io.perfume.api.base.LogLevel;
 import org.springframework.http.HttpStatus;
 
-public class FailedLeaveException extends CustomHttpException {
-    public FailedLeaveException(String message, String logMessage)
+public class FailedToLeaveException extends CustomHttpException {
+    public FailedToLeaveException(String message, String logMessage)
     {
         super(HttpStatus.UNAUTHORIZED, message, logMessage, LogLevel.WARN);
     }

--- a/perfume-api/src/main/java/io/perfume/api/user/application/port/in/LeaveUserUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/port/in/LeaveUserUseCase.java
@@ -1,0 +1,11 @@
+package io.perfume.api.user.application.port.in;
+
+public interface LeaveUserUseCase {
+
+    /**
+     * 본인의 계정을 탈퇴처리한다.
+     *
+     * @param accessToken 삭제를 위한 User 데이터 조회에 필요한 값이 담겨있다.
+     */
+    void leave(String accessToken);
+}

--- a/perfume-api/src/main/java/io/perfume/api/user/application/port/in/LeaveUserUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/port/in/LeaveUserUseCase.java
@@ -5,7 +5,7 @@ public interface LeaveUserUseCase {
     /**
      * 본인의 계정을 탈퇴처리한다.
      *
-     * @param accessToken 삭제를 위한 User 데이터 조회에 필요한 값이 담겨있다.
+     * @param userId 회원 탈퇴를 희망하는 사용자 데이터 식별자
      */
-    void leave(String accessToken);
+    void leave(Long userId);
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/application/service/SupportUserService.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/service/SupportUserService.java
@@ -1,12 +1,15 @@
 package io.perfume.api.user.application.service;
 
 import encryptor.OneWayEncryptor;
+import io.perfume.api.user.application.exception.FailedLeaveException;
 import io.perfume.api.user.application.exception.NotFoundUserException;
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
+import io.perfume.api.user.application.port.in.LeaveUserUseCase;
 import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
 import io.perfume.api.user.application.port.out.UserQueryRepository;
 import io.perfume.api.user.application.port.out.UserRepository;
 import io.perfume.api.user.domain.User;
+import jwt.JsonWebTokenGenerator;
 import lombok.RequiredArgsConstructor;
 import mailer.MailSender;
 import org.springframework.stereotype.Service;
@@ -17,7 +20,7 @@ import java.time.LocalDateTime;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class SupportUserService implements SendResetPasswordMailUseCase, FindEncryptedUsernameUseCase {
+public class SupportUserService implements SendResetPasswordMailUseCase, FindEncryptedUsernameUseCase, LeaveUserUseCase {
 
     private final UserQueryRepository userQueryRepository; 
 
@@ -25,13 +28,14 @@ public class SupportUserService implements SendResetPasswordMailUseCase, FindEnc
     private final MailSender mailSender;
     private final OneWayEncryptor oneWayEncryptor;
 
+    private final JsonWebTokenGenerator jsonWebTokenGenerator;
+
     /**
      * TODO
      * 비밀번호 변경파트 고민하기
      * 1. 이메일과 아이디를 알면 누구나 다른 사용자의 암호를 수정할 수 있음
      * 2. "새로운 패스워드 할당" 이메일 템플릿 정하기
      */
-    @Transactional
     @Override
     public void sendNewPasswordToEmail(String email, String username) {
         User user = userQueryRepository.findOneByEmailAndUsername(email, username).orElseThrow(NotFoundUserException::new);
@@ -54,4 +58,33 @@ public class SupportUserService implements SendResetPasswordMailUseCase, FindEnc
         User user = userQueryRepository.findOneByEmail(email).orElseThrow(NotFoundUserException::new);
         return user.getEncryptedUsername();
     }
+
+    @Override
+    public void leave(String accessToken)
+    {
+        Long userId = null;
+
+        try {
+            // TODO 'userId'같은 상수값이 사용할 때 마다 정의해서 사용중, 상수값을 모아서 관리하고싶음
+            userId = jsonWebTokenGenerator.getClaim(accessToken, "usdId", Long.class);
+
+            User user = userQueryRepository.loadUser(userId).orElseThrow(NotFoundUserException::new);
+
+            LocalDateTime now = LocalDateTime.now();
+
+            user.softDelete(now);
+
+            userRepository.save(user);
+
+        } catch (NotFoundUserException e) {
+
+            FailedLeaveException failedLeaveException = new FailedLeaveException("회원탈퇴 실패", "user id : " + userId + ", 회원탈퇴 실패");
+
+            failedLeaveException.initCause(e);
+
+            throw failedLeaveException;
+
+        }
+    }
+
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/application/service/SupportUserService.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/service/SupportUserService.java
@@ -1,7 +1,7 @@
 package io.perfume.api.user.application.service;
 
 import encryptor.OneWayEncryptor;
-import io.perfume.api.user.application.exception.FailedLeaveException;
+import io.perfume.api.user.application.exception.FailedToLeaveException;
 import io.perfume.api.user.application.exception.NotFoundUserException;
 import io.perfume.api.user.application.port.in.FindEncryptedUsernameUseCase;
 import io.perfume.api.user.application.port.in.LeaveUserUseCase;
@@ -37,6 +37,7 @@ public class SupportUserService implements SendResetPasswordMailUseCase, FindEnc
      * 2. "새로운 패스워드 할당" 이메일 템플릿 정하기
      */
     @Override
+    @Transactional
     public void sendNewPasswordToEmail(String email, String username) {
         User user = userQueryRepository.findOneByEmailAndUsername(email, username).orElseThrow(NotFoundUserException::new);
 
@@ -60,13 +61,10 @@ public class SupportUserService implements SendResetPasswordMailUseCase, FindEnc
     }
 
     @Override
-    public void leave(String accessToken)
+    public void leave(Long userId)
     {
-        Long userId = null;
 
         try {
-            // TODO 'userId'같은 상수값이 사용할 때 마다 정의해서 사용중, 상수값을 모아서 관리하고싶음
-            userId = jsonWebTokenGenerator.getClaim(accessToken, "usdId", Long.class);
 
             User user = userQueryRepository.loadUser(userId).orElseThrow(NotFoundUserException::new);
 
@@ -78,7 +76,7 @@ public class SupportUserService implements SendResetPasswordMailUseCase, FindEnc
 
         } catch (NotFoundUserException e) {
 
-            FailedLeaveException failedLeaveException = new FailedLeaveException("회원탈퇴 실패", "user id : " + userId + ", 회원탈퇴 실패");
+            FailedToLeaveException failedLeaveException = new FailedToLeaveException("회원탈퇴 실패", "user id : " + userId + ", 회원탈퇴 실패");
 
             failedLeaveException.initCause(e);
 

--- a/perfume-api/src/main/java/io/perfume/api/user/domain/User.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/domain/User.java
@@ -26,6 +26,15 @@ public class User extends BaseTimeDomain {
   private Long thumbnailId;
 
   /**
+   *  사용자의 회원탈퇴(soft delete)
+   *
+   *  @param now 삭제 시간에 할당되는 값
+   */
+  public void softDelete(LocalDateTime now) {
+    super.markDelete(now);
+  }
+
+  /**
    * 현재 user의 username 필드 앞에서 "username.length / 2"만큼 "*" 치환하여 반환한다.
    *
    * @return 암호화된 username


### PR DESCRIPTION
## What is this PR? 👀

delete "/v1/user" API 작성, 사용자는 api호출 시 회원탈퇴(soft delete)

탈퇴 성공 시 http status 202
탈퇴 실패 시 http status 401을 반환

- Issue ticket number: RDPF - 64

## Changes ✏️

1. perfume-api/src/main/java/io/perfume/api/auth/application/service/AuthenticationTokenService.java에 간단한 개선사항 TODO 작성
2. User Model에 softDelete() 메서드 작성

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
