### PR TITLE
[RDPF-63] 마이페이지 상세화면에 필요한 자신의 정보 조회 UseCase 작성

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileJpaEntity.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileJpaEntity.java
@@ -6,11 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.jetbrains.annotations.NotNull;
 
 @Entity(name = "file")
@@ -29,4 +25,10 @@ public class FileJpaEntity extends BaseTimeEntity {
 
   @NotNull
   private String url;
+
+  @Builder(access = AccessLevel.PACKAGE)
+  public FileJpaEntity(long id, String url) {
+      this.id = id;
+      this.url = url;
+  }
 }

--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileJpaEntity.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.Where;
 import org.jetbrains.annotations.NotNull;
 
 @Entity(name = "file")
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @ToString(onlyExplicitlyIncluded = true)
 @Getter
+@Where(clause = "deleted_at is null") // TODO 'FileEntity'의 경우 'JpaRepository'의 조회기능 사용하므로 임시 조치, 사유 : QClass가 생성이 안된다.
 public class FileJpaEntity extends BaseTimeEntity {
 
   @Id

--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileMapper.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileMapper.java
@@ -1,0 +1,19 @@
+package io.perfume.api.file.adapter.out.persistence;
+
+import io.perfume.api.file.domain.File;
+
+public class FileMapper {
+    public File toDomain(FileJpaEntity entity) {
+        if(entity == null) {
+            return null;
+        }
+        return File.withId(
+                entity.getId(),
+                entity.getUrl(),
+                entity.getCreatedAt(),
+                entity.getDeletedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileMapper.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileMapper.java
@@ -1,7 +1,9 @@
 package io.perfume.api.file.adapter.out.persistence;
 
 import io.perfume.api.file.domain.File;
+import org.springframework.stereotype.Component;
 
+@Component
 public class FileMapper {
     public File toDomain(FileJpaEntity entity) {
         if(entity == null) {

--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileQueryPersistenceAdapter.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileQueryPersistenceAdapter.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class FileQueryQueryPersistenceAdapter implements FileQueryRepository {
+public class FileQueryPersistenceAdapter implements FileQueryRepository {
 
     // TODO QFileJpaEntity가 생성이 안되서 JpaRepository 임시 사용
     private final JPAQueryFactory jpaQueryFactory;

--- a/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileQueryQueryPersistenceAdapter.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/adapter/out/persistence/FileQueryQueryPersistenceAdapter.java
@@ -1,0 +1,28 @@
+package io.perfume.api.file.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.perfume.api.base.PersistenceAdapter;
+import io.perfume.api.file.application.port.out.FileQueryRepository;
+import io.perfume.api.file.domain.File;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional(readOnly = true)
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class FileQueryQueryPersistenceAdapter implements FileQueryRepository {
+
+    // TODO QFileJpaEntity가 생성이 안되서 JpaRepository 임시 사용
+    private final JPAQueryFactory jpaQueryFactory;
+    private final FileJpaRepository fileJpaRepository;
+    private final FileMapper fileMapper;
+
+    @Override
+    public Optional<File> loadFile(Long fileId) {
+        FileJpaEntity fileJpaEntity = fileJpaRepository.findById(fileId).orElseGet(null);
+        File nullableFile = fileMapper.toDomain(fileJpaEntity);
+        return Optional.ofNullable(nullableFile);
+    }
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/exception/NotFoundFileException.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/exception/NotFoundFileException.java
@@ -1,0 +1,4 @@
+package io.perfume.api.file.application.exception;
+
+public class NotFoundFileException extends RuntimeException {
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/port/in/FindFileUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/port/in/FindFileUseCase.java
@@ -1,0 +1,15 @@
+package io.perfume.api.file.application.port.in;
+
+import io.perfume.api.file.application.port.in.dto.FileResult;
+import io.perfume.api.file.domain.File;
+
+public interface FindFileUseCase {
+
+    /**
+     * File을 1개 조회한다.
+     *
+     * @param fileId file pk
+     * @return fileDTO
+     */
+    FileResult findFile(Long fileId);
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/port/in/dto/FileResult.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/port/in/dto/FileResult.java
@@ -1,0 +1,8 @@
+package io.perfume.api.file.application.port.in.dto;
+
+public record FileResult (
+        Long id,
+        String url
+) {
+
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/port/out/FileQueryRepository.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/port/out/FileQueryRepository.java
@@ -1,0 +1,9 @@
+package io.perfume.api.file.application.port.out;
+
+import io.perfume.api.file.domain.File;
+
+import java.util.Optional;
+
+public interface FileQueryRepository {
+    Optional<File> loadFile(Long fileId);
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/port/out/FileRepository.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/port/out/FileRepository.java
@@ -1,4 +1,0 @@
-package io.perfume.api.file.application.port.out;
-
-public interface FileRepository {
-}

--- a/perfume-api/src/main/java/io/perfume/api/file/application/service/FileService.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/application/service/FileService.java
@@ -1,0 +1,26 @@
+package io.perfume.api.file.application.service;
+
+import io.perfume.api.file.application.exception.NotFoundFileException;
+import io.perfume.api.file.application.port.in.FindFileUseCase;
+import io.perfume.api.file.application.port.in.dto.FileResult;
+import io.perfume.api.file.application.port.out.FileQueryRepository;
+import io.perfume.api.file.domain.File;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FileService implements FindFileUseCase {
+
+    private final FileQueryRepository fileQueryRepository;
+
+    @Override
+    public FileResult findFile(Long fileId) {
+        File file = fileQueryRepository.loadFile(fileId).orElseThrow(NotFoundFileException::new);
+        return toDto(file);
+    }
+
+    private FileResult toDto(File file) {
+        return new FileResult(file.getId(), file.getUrl());
+    }
+}

--- a/perfume-api/src/main/java/io/perfume/api/file/domain/File.java
+++ b/perfume-api/src/main/java/io/perfume/api/file/domain/File.java
@@ -2,8 +2,12 @@ package io.perfume.api.file.domain;
 
 import io.perfume.api.base.BaseTimeDomain;
 import java.time.LocalDateTime;
+
+import io.perfume.api.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 
 @Getter
 public class File extends BaseTimeDomain {
@@ -12,7 +16,7 @@ public class File extends BaseTimeDomain {
 
   private final String url;
 
-  @Builder
+  @Builder(access = AccessLevel.PACKAGE)
   private File(Long id, String url, LocalDateTime createdAt, LocalDateTime updatedAt,
                LocalDateTime deletedAt) {
     super(createdAt, updatedAt, deletedAt);
@@ -20,4 +24,18 @@ public class File extends BaseTimeDomain {
     this.id = id;
     this.url = url;
   }
+
+  // Only Adapter
+  public static File withId(
+          Long id, String url, LocalDateTime createdAt,
+          LocalDateTime deletedAt, LocalDateTime updatedAt) {
+      return File.builder()
+              .id(id)
+              .url(url)
+              .createdAt(createdAt)
+              .updatedAt(updatedAt)
+              .deletedAt(deletedAt)
+              .build();
+  }
+
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/MyInformationController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/MyInformationController.java
@@ -1,0 +1,24 @@
+package io.perfume.api.user.adapter.in.http;
+
+import io.perfume.api.user.adapter.in.http.dto.FindMyDetailInformationResponseDto;
+import io.perfume.api.user.application.port.in.FindMyDetailInformationUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user")
+public class MyInformationController {
+
+    private final FindMyDetailInformationUseCase findMyDetailInformationUseCase;
+
+    @GetMapping
+    public ResponseEntity<FindMyDetailInformationResponseDto> findMyDetailInformation(@RequestHeader(value = "Authorization") String accessToken) {
+        FindMyDetailInformationResponseDto myDetailInformation = findMyDetailInformationUseCase.findMyDetailInformation(accessToken);
+        return ResponseEntity.ok(myDetailInformation);
+    }
+}

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/UsersSupportController.java
@@ -36,5 +36,4 @@ public class UsersSupportController {
         String encryptedUsername = findEncryptedUsernameUseCase.findEncryptedUsername(email);
         return ResponseEntity.ok(encryptedUsername);
     }
-
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/dto/FindMyDetailInformationResponseDto.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/in/http/dto/FindMyDetailInformationResponseDto.java
@@ -1,0 +1,15 @@
+package io.perfume.api.user.adapter.in.http.dto;
+
+import java.time.LocalDate;
+
+public record FindMyDetailInformationResponseDto(
+    String username,
+    String name,
+    String bio,
+    String picture,
+    String email,
+    LocalDate birth,
+    Boolean isOauth
+) {
+
+}

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/user/UserJpaEntity.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/user/UserJpaEntity.java
@@ -16,6 +16,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -73,16 +75,24 @@ public class UserJpaEntity extends BaseTimeEntity {
   @NotNull
   private Boolean promotionConsent = false;
 
+  @NotNull
+  private Boolean isOauth = false;
+
+  private LocalDate birth;
+
+  private String bio;
+
   private Long businessId;
 
   private Long thumbnailId;
+
 
   // Mapper Library 필요
   @Builder(access = AccessLevel.PACKAGE)
   public UserJpaEntity(Long id, String username, String email, String password,
                        String name, Role role, Boolean marketingConsent,
                        Boolean promotionConsent, LocalDateTime createdAt, LocalDateTime updatedAt,
-                       LocalDateTime deletedAt) {
+                       LocalDate birth, LocalDateTime deletedAt, Boolean isOauth, String bio) {
     super(createdAt, updatedAt, deletedAt);
     this.id = id;
     this.username = username;
@@ -92,5 +102,8 @@ public class UserJpaEntity extends BaseTimeEntity {
     this.role = role;
     this.marketingConsent = marketingConsent;
     this.promotionConsent = promotionConsent;
+    this.birth = birth;
+    this.isOauth = isOauth;
+    this.bio = bio;
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/user/UserMapper.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/adapter/out/persistence/user/UserMapper.java
@@ -21,7 +21,9 @@ public class UserMapper {
         userJpaEntity.getThumbnailId(),
         userJpaEntity.getCreatedAt(),
         userJpaEntity.getUpdatedAt(),
-        userJpaEntity.getDeletedAt());
+        userJpaEntity.getDeletedAt(),
+        userJpaEntity.getBirth(),
+        userJpaEntity.getIsOauth());
   }
 
   public UserJpaEntity toUserJpaEntity(User user) {
@@ -40,6 +42,8 @@ public class UserMapper {
         .createdAt(user.getCreatedAt())
         .updatedAt(user.getUpdatedAt())
         .deletedAt(user.getDeletedAt())
+        .birth(user.getBirth())
+        .isOauth(user.getIsOauth())
         .build();
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/application/port/in/FindMyDetailInformationUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/port/in/FindMyDetailInformationUseCase.java
@@ -1,0 +1,14 @@
+package io.perfume.api.user.application.port.in;
+
+import io.perfume.api.user.adapter.in.http.dto.FindMyDetailInformationResponseDto;
+
+public interface FindMyDetailInformationUseCase {
+
+    /**
+     * 자신의 자세한 정보를 반환
+     *
+     * @param accessToken 자신의 정보를 찾을 때 필요한 값이 포함
+     * @return
+     */
+    FindMyDetailInformationResponseDto findMyDetailInformation(String accessToken);
+}

--- a/perfume-api/src/main/java/io/perfume/api/user/application/service/FindUserService.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/application/service/FindUserService.java
@@ -1,31 +1,35 @@
 package io.perfume.api.user.application.service;
 
-import encryptor.OneWayEncryptor;
+import io.perfume.api.file.application.port.in.FindFileUseCase;
+import io.perfume.api.file.application.port.in.dto.FileResult;
+import io.perfume.api.file.domain.File;
+import io.perfume.api.user.adapter.in.http.dto.FindMyDetailInformationResponseDto;
 import io.perfume.api.user.application.exception.NotFoundUserException;
+import io.perfume.api.user.application.port.in.FindMyDetailInformationUseCase;
 import io.perfume.api.user.application.port.in.FindUserUseCase;
-import io.perfume.api.user.application.port.in.SendResetPasswordMailUseCase;
 import io.perfume.api.user.application.port.in.dto.UserResult;
 import io.perfume.api.user.application.port.out.SocialAccountQueryRepository;
 import io.perfume.api.user.application.port.out.UserQueryRepository;
 import io.perfume.api.user.domain.SocialAccount;
 import io.perfume.api.user.domain.User;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
+
+import jwt.JsonWebTokenGenerator;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-public class FindUserService implements FindUserUseCase {
+@RequiredArgsConstructor
+public class FindUserService implements FindUserUseCase, FindMyDetailInformationUseCase {
 
   private final UserQueryRepository userQueryRepository;
 
   private final SocialAccountQueryRepository oauthQueryRepository;
 
-  public FindUserService(UserQueryRepository userQueryRepository,
-                         SocialAccountQueryRepository oauthQueryRepository) {
-    this.userQueryRepository = userQueryRepository;
-    this.oauthQueryRepository = oauthQueryRepository;
-  }
+  private final FindFileUseCase findFileUseCase;
+  private final JsonWebTokenGenerator jsonWebTokenGenerator;
+
 
   @Override
   public Optional<UserResult> findOneByEmail(String email) {
@@ -45,5 +49,24 @@ public class FindUserService implements FindUserUseCase {
   private UserResult toDto(SocialAccount socialAccount) {
     return toDto(socialAccount.getUser());
   }
-  
+
+  @Override
+  public FindMyDetailInformationResponseDto findMyDetailInformation(String accessToken) {
+
+    Long userId = jsonWebTokenGenerator.getClaim(accessToken, "userId", Long.class);
+
+    User user = userQueryRepository.loadUser(userId).orElseThrow(NotFoundUserException::new);
+
+    FileResult file = findFileUseCase.findFile(user.getThumbnailId());
+
+    return new FindMyDetailInformationResponseDto(
+            user.getUsername(),
+            user.getName(),
+            user.getBio(),
+            file.url(),
+            user.getEmail(),
+            user.getBirth(),
+            user.getIsOauth()
+    );
+  }
 }

--- a/perfume-api/src/main/java/io/perfume/api/user/domain/User.java
+++ b/perfume-api/src/main/java/io/perfume/api/user/domain/User.java
@@ -3,6 +3,8 @@ package io.perfume.api.user.domain;
 import com.mysql.cj.util.StringUtils;
 import encryptor.OneWayEncryptor;
 import io.perfume.api.base.BaseTimeDomain;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
@@ -24,6 +26,10 @@ public class User extends BaseTimeDomain {
   private boolean promotionConsent;
   private Long businessId;
   private Long thumbnailId;
+  private LocalDate birth;
+
+  private String bio;
+  private Boolean isOauth;
 
   /**
    * 현재 user의 username 필드 앞에서 "username.length / 2"만큼 "*" 치환하여 반환한다.
@@ -60,7 +66,8 @@ public class User extends BaseTimeDomain {
   private User(Long id, String username, String email, String password,
                String name, Role role, Long businessId,
                Long thumbnailId, LocalDateTime createdAt, LocalDateTime updatedAt,
-               LocalDateTime deletedAt, boolean marketingConsent, boolean promotionConsent) {
+               LocalDateTime deletedAt, boolean marketingConsent, boolean promotionConsent, LocalDate birth,
+               Boolean isOauth, String bio) {
     super(createdAt, updatedAt, deletedAt);
     this.id = id;
     this.username = username;
@@ -72,6 +79,9 @@ public class User extends BaseTimeDomain {
     this.thumbnailId = thumbnailId;
     this.marketingConsent = marketingConsent;
     this.promotionConsent = promotionConsent;
+    this.birth = birth;
+    this.isOauth = isOauth;
+    this.bio = bio;
   }
 
   // 기업 사용자가 아닌 경우 회원가입시에 사용됩니다.
@@ -85,6 +95,7 @@ public class User extends BaseTimeDomain {
         .role(Role.USER)
         .marketingConsent(marketingConsent)
         .promotionConsent(promotionConsent)
+        .isOauth(false)
         .build();
   }
 
@@ -101,6 +112,7 @@ public class User extends BaseTimeDomain {
         .createdAt(now)
         .updatedAt(now)
         .deletedAt(null)
+        .isOauth(true)
         .build();
   }
 
@@ -109,7 +121,7 @@ public class User extends BaseTimeDomain {
       Long id, String username, String email,
       String password, String name, Role role,
       Long businessId, Long thumbnailId, LocalDateTime createdAt, LocalDateTime updatedAt,
-      LocalDateTime deletedAt) {
+      LocalDateTime deletedAt, LocalDate birth, Boolean isOauth) {
     return User.builder()
         .id(id)
         .username(username)
@@ -122,6 +134,8 @@ public class User extends BaseTimeDomain {
         .createdAt(createdAt)
         .updatedAt(updatedAt)
         .deletedAt(deletedAt)
+        .birth(birth)
+        .isOauth(isOauth)
         .build();
   }
 }

--- a/perfume-api/src/test/java/io/perfume/api/user/adapter/out/persistence/user/UserQueryPersistenceAdapterTest.java
+++ b/perfume-api/src/test/java/io/perfume/api/user/adapter/out/persistence/user/UserQueryPersistenceAdapterTest.java
@@ -34,7 +34,7 @@ class UserQueryPersistenceAdapterTest {
     LocalDateTime now = LocalDateTime.now();
     entityManager.persist(
         new UserJpaEntity(
-            null, "username", email, "abcd", "abcd", Role.USER, false, false, now, now, null
+            null, "username", email, "abcd", "abcd", Role.USER, false, false, now, now, null, null, true, "not found bio"
         )
     );
     entityManager.flush();
@@ -54,7 +54,7 @@ class UserQueryPersistenceAdapterTest {
     String username = "username";
     LocalDateTime now = LocalDateTime.now();
     UserJpaEntity entity = new UserJpaEntity(
-        null, username, "test@mail.com", "abcd", "abcd", Role.USER, false, false, now, now, null
+        null, username, "test@mail.com", "abcd", "abcd", Role.USER, false, false, now, now, null, null, false, "not found bio"
     );
     entityManager.persist(entity);
     entityManager.flush();
@@ -75,7 +75,7 @@ class UserQueryPersistenceAdapterTest {
     LocalDateTime now = LocalDateTime.now();
     entityManager.persist(
         new UserJpaEntity(
-            null, username, "test@mail.com", "abcd", "abcd", Role.USER, false, false, now, now, null
+            null, username, "test@mail.com", "abcd", "abcd", Role.USER, false, false, now, now, null, null, false, "not found bio"
         ));
     entityManager.flush();
     entityManager.clear();


### PR DESCRIPTION
## What is this PR? 👀

요청에 포함된 토큰을 사용하여 자신의 디테일 페이지에 사용할 정보를 조회하는 기능 생성

- Issue ticket number: RDPF-63

## Changes ✏️

1. "/api/v1/user" api 작성, 요청에 포함된 토큰을 사용하여 자신의 디테일 페이지에 사용할 정보를 조회
2.  1번 기능 구현을 위해 File Domain 추가 개발 (추가된 usecase : FileId를 사용하여 File 1개를 조회할 수 있다.)
3. User Table에 isOauth, bio, birth 컬럼 생성 (jpa entity, domail model에도 생성)
4. user table column 추가로 관련된 test code, logic 수정 (UserJpaEntity 생성자 인자 추가, 가입 시 isOauth 할당 추가 적용..)

<br><br>
추가 컬럼 : is_oauth, bio, birth

<img width="727" alt="스크린샷 2023-07-22 오후 9 50 31" src="https://github.com/read-a-perfume/backend/assets/80996897/aff5bd6c-a743-41db-8ba0-cfd1372252d7">

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
