### PR TITLE
[RDPF-197] 브랜드의 향수 목록을 무한스크롤로 가져오도록 API 구현

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/PerfumeController.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/PerfumeController.java
@@ -2,16 +2,23 @@ package io.perfume.api.perfume.adapter.in.http;
 
 import io.perfume.api.perfume.adapter.in.http.dto.CreatePerfumeRequestDto;
 import io.perfume.api.perfume.adapter.in.http.dto.PerfumeResponseDto;
+import io.perfume.api.perfume.adapter.in.http.dto.SimplePerfumeResponseDto;
 import io.perfume.api.perfume.application.port.in.CreatePerfumeUseCase;
 import io.perfume.api.perfume.application.port.in.FindPerfumeUseCase;
 import io.perfume.api.perfume.application.port.in.dto.CreatePerfumeCommand;
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
+import jakarta.annotation.Nullable;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,5 +42,13 @@ public class PerfumeController {
     CreatePerfumeCommand createPerfumeCommand = createPerfumeRequestDto.toCommand();
 
     createPerfumeUseCase.createPerfume(createPerfumeCommand);
+  }
+
+  @GetMapping
+  public Slice<SimplePerfumeResponseDto> getPerfumesByBrand(@RequestParam Long brandId, @RequestParam @Nullable Long lastPerfumeId,
+                                                            @RequestParam int pageSize) {
+    Slice<SimplePerfumeResult> perfumesByBrand = findPerfumeUseCase.findPerfumesByBrand(brandId, lastPerfumeId, pageSize);
+    List<SimplePerfumeResponseDto> list = perfumesByBrand.getContent().stream().map(SimplePerfumeResponseDto::of).toList();
+    return new SliceImpl<>(list, perfumesByBrand.getPageable(), perfumesByBrand.hasNext());
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/dto/SimplePerfumeResponseDto.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/dto/SimplePerfumeResponseDto.java
@@ -1,0 +1,16 @@
+package io.perfume.api.perfume.adapter.in.http.dto;
+
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
+
+public record SimplePerfumeResponseDto(Long id, String name, String thumbnailUrl, String brandName, String strength, String duration) {
+  public static SimplePerfumeResponseDto of(SimplePerfumeResult simplePerfumeResult) {
+    return new SimplePerfumeResponseDto(
+        simplePerfumeResult.id(),
+        simplePerfumeResult.name(),
+        simplePerfumeResult.thumbnailUrl(),
+        simplePerfumeResult.brandName(),
+        simplePerfumeResult.concentration().getStrength(),
+        simplePerfumeResult.concentration().getDuration()
+    );
+  }
+}

--- a/perfume-api/src/main/java/io/perfume/api/perfume/adapter/out/persistence/perfume/PerfumeQueryPersistenceAdapter.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/adapter/out/persistence/perfume/PerfumeQueryPersistenceAdapter.java
@@ -1,14 +1,19 @@
 package io.perfume.api.perfume.adapter.out.persistence.perfume;
 
+import static io.perfume.api.brand.adapter.out.persistence.QBrandEntity.brandEntity;
+import static io.perfume.api.file.adapter.out.persistence.file.QFileJpaEntity.fileJpaEntity;
 import static io.perfume.api.note.adapter.out.persistence.note.QNoteJpaEntity.noteJpaEntity;
 import static io.perfume.api.perfume.adapter.out.persistence.perfume.QPerfumeJpaEntity.perfumeJpaEntity;
 import static io.perfume.api.perfume.adapter.out.persistence.perfumeNote.QPerfumeNoteEntity.perfumeNoteEntity;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.perfume.api.base.PersistenceAdapter;
 import io.perfume.api.perfume.adapter.out.persistence.perfume.mapper.PerfumeMapper;
 import io.perfume.api.perfume.adapter.out.persistence.perfumeNote.PerfumeNoteJpaRepository;
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import io.perfume.api.perfume.application.port.out.PerfumeQueryRepository;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.Perfume;
@@ -16,6 +21,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -49,5 +57,37 @@ public class PerfumeQueryPersistenceAdapter implements PerfumeQueryRepository {
         .fetch();
 
     return perfumeMapper.toNotePyramid(result);
+  }
+
+  @Override
+  public Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize) {
+    List<SimplePerfumeResult> results = jpaQueryFactory.select(
+            Projections.constructor(SimplePerfumeResult.class, perfumeJpaEntity.id, perfumeJpaEntity.name, perfumeJpaEntity.concentration,
+                brandEntity.name, fileJpaEntity.url))
+        .from(perfumeJpaEntity)
+        .where(ltPerfumeId(lastPerfumeId),
+            perfumeJpaEntity.brandId.eq(brandId),
+            perfumeJpaEntity.deletedAt.isNull())
+        .leftJoin(brandEntity).on(perfumeJpaEntity.brandId.eq(brandEntity.id)).fetchJoin()
+        .leftJoin(fileJpaEntity).on(perfumeJpaEntity.thumbnailId.eq(fileJpaEntity.id)).fetchJoin()
+        .orderBy(perfumeJpaEntity.id.desc())
+        .limit(pageSize + 1L)
+        .fetch();
+
+    boolean hasNext = false;
+    if (results.size() > pageSize) {
+      results.remove(pageSize);
+      hasNext = true;
+    }
+
+    return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+  }
+
+  private BooleanExpression ltPerfumeId(Long perfumeId) {
+    if (perfumeId == null) {
+      return null;
+    }
+
+    return perfumeJpaEntity.id.lt(perfumeId);
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/adapter/out/persistence/perfume/mapper/PerfumeMapper.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/adapter/out/persistence/perfume/mapper/PerfumeMapper.java
@@ -1,12 +1,16 @@
 package io.perfume.api.perfume.adapter.out.persistence.perfume.mapper;
 
+import static io.perfume.api.brand.adapter.out.persistence.QBrandEntity.brandEntity;
+import static io.perfume.api.file.adapter.out.persistence.file.QFileJpaEntity.fileJpaEntity;
 import static io.perfume.api.note.adapter.out.persistence.note.QNoteJpaEntity.noteJpaEntity;
+import static io.perfume.api.perfume.adapter.out.persistence.perfume.QPerfumeJpaEntity.perfumeJpaEntity;
 import static io.perfume.api.perfume.adapter.out.persistence.perfumeNote.QPerfumeNoteEntity.perfumeNoteEntity;
 
 import com.querydsl.core.Tuple;
 import io.perfume.api.perfume.adapter.out.persistence.perfume.PerfumeJpaEntity;
 import io.perfume.api.perfume.adapter.out.persistence.perfumeNote.NoteLevel;
 import io.perfume.api.perfume.adapter.out.persistence.perfumeNote.PerfumeNoteEntity;
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.NotePyramidIds;
 import io.perfume.api.perfume.domain.Perfume;
@@ -151,6 +155,22 @@ public class PerfumeMapper {
         .perfumeId(perfumeId)
         .noteId(noteId)
         .noteLevel(noteLevel)
+        .build();
+  }
+
+  public List<SimplePerfumeResult> toSimplePerfumeResults(List<Tuple> fetchedTuples) {
+    return fetchedTuples.stream()
+        .map(this::toSimplePerfumeResult)
+        .toList();
+  }
+
+  private SimplePerfumeResult toSimplePerfumeResult(Tuple tuple) {
+    return SimplePerfumeResult.builder()
+        .id(tuple.get(perfumeJpaEntity.id))
+        .name(tuple.get(perfumeJpaEntity.name))
+        .concentration(tuple.get(perfumeJpaEntity.concentration))
+        .brandName(tuple.get(brandEntity.name))
+        .thumbnailUrl(tuple.get(fileJpaEntity.url))
         .build();
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/FindPerfumeUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/FindPerfumeUseCase.java
@@ -1,8 +1,14 @@
 package io.perfume.api.perfume.application.port.in;
 
 import io.perfume.api.perfume.application.port.in.dto.PerfumeResult;
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface FindPerfumeUseCase {
 
   PerfumeResult findPerfumeById(Long id);
+
+  Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize);
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/dto/SimplePerfumeResult.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/dto/SimplePerfumeResult.java
@@ -1,0 +1,19 @@
+package io.perfume.api.perfume.application.port.in.dto;
+
+import io.perfume.api.brand.application.port.in.dto.BrandForPerfumeResult;
+import io.perfume.api.perfume.domain.Concentration;
+import io.perfume.api.perfume.domain.Perfume;
+import lombok.Builder;
+
+@Builder
+public record SimplePerfumeResult(Long id, String name, Concentration concentration, String brandName, String thumbnailUrl) {
+  public static SimplePerfumeResult from(Perfume perfume, BrandForPerfumeResult brandResult) {
+    return SimplePerfumeResult.builder()
+        .id(perfume.getId())
+        .name(perfume.getName())
+        .concentration(perfume.getConcentration())
+        .brandName(brandResult.name())
+        .thumbnailUrl(null) // TODO: 썸네일 추가
+        .build();
+  }
+}

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/port/out/PerfumeQueryRepository.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/port/out/PerfumeQueryRepository.java
@@ -1,12 +1,16 @@
 package io.perfume.api.perfume.application.port.out;
 
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.Perfume;
 import java.util.Optional;
+import org.springframework.data.domain.Slice;
 
 public interface PerfumeQueryRepository {
 
   Optional<Perfume> findPerfumeById(Long id);
 
   NotePyramid getNotePyramidByPerfume(Long perfumeId);
+
+  Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize);
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/service/FindPerfumeService.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/service/FindPerfumeService.java
@@ -7,10 +7,12 @@ import io.perfume.api.note.application.port.in.dto.CategoryResult;
 import io.perfume.api.perfume.application.exception.PerfumeNotFoundException;
 import io.perfume.api.perfume.application.port.in.FindPerfumeUseCase;
 import io.perfume.api.perfume.application.port.in.dto.PerfumeResult;
+import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import io.perfume.api.perfume.application.port.out.PerfumeQueryRepository;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.Perfume;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,5 +32,10 @@ public class FindPerfumeService implements FindPerfumeUseCase {
     // TODO: file의 thumbnail을 얻어와야 한다.
 
     return PerfumeResult.from(perfume, categoryResult, brandResult, notePyramid);
+  }
+
+  @Override
+  public Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize) {
+    return perfumeQueryRepository.findPerfumesByBrand(brandId, lastPerfumeId, pageSize);
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/domain/Concentration.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/domain/Concentration.java
@@ -1,9 +1,20 @@
 package io.perfume.api.perfume.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Concentration {
-  EAU_FRAICHE,
-  EAU_DE_COLOGNE,
-  EAU_DE_TOILETTE,
-  EAU_DE_PERFUME,
-  PERFUME
+  EAU_FRAICHE("매우 가벼운 향", "1시간-2시간"),
+  EAU_DE_COLOGNE("가벼운 향", "2시간-3시간"),
+  EAU_DE_TOILETTE("적당한 향", "3시간-6시간"),
+  EAU_DE_PERFUME("진한 향", "6시간-8시간"),
+  PERFUME("아주 진한 향", "최대 24시간");
+
+  private final String strength;
+  private final String duration;
+
+  private Concentration(String strength, String duration) {
+    this.strength = strength;
+    this.duration = duration;
+  }
 }


### PR DESCRIPTION
## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- Issue ticket number: RDPF-197
- 브랜드에 해당하는 향수 목록을 무한스크롤로 가져오도록 API를 구현했습니다.
- `/api/v1/perfumes?brandId=1&lastPerfumeId=45&pageSize=6`  과 같이 요청을 보내면 다음과 같이 응답이 오게 됩니다.
```json
{
    "content": [
        {
            "id": 33,
            "name": "블랙베리 앤 베이14",
            "thumbnailUrl": null,
            "brandName": "조말론",
            "strength": "적당한 향",
            "duration": "3시간-6시간"
        },
        {
            "id": 32,
            "name": "블랙베리 앤 베이13",
            "thumbnailUrl": null,
            "brandName": "조말론",
            "strength": "적당한 향",
            "duration": "3시간-6시간"
        },
        {
            "id": 31,
            "name": "블랙베리 앤 베이12",
            "thumbnailUrl": null,
            "brandName": "조말론",
            "strength": "적당한 향",
            "duration": "3시간-6시간"
        }
    ],
    "pageable": {
        "pageNumber": 1,
        "pageSize": 1,
        "sort": {
            "empty": true,
            "unsorted": true,
            "sorted": false
        },
        "offset": 1,
        "paged": true,
        "unpaged": false
    },
    "first": false,
    "last": false,
    "size": 1,
    "number": 1,
    "sort": {
        "empty": true,
        "unsorted": true,
        "sorted": false
    },
    "numberOfElements": 3,
    "empty": false
}
```
## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
-

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
