### PR TITLE
[RDPF-201] 카테고리 별 향수 목록 조회 기능 추가

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/note/adapter/out/persistence/category/CategoryJpaEntity.java
+++ b/perfume-api/src/main/java/io/perfume/api/note/adapter/out/persistence/category/CategoryJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +41,7 @@ public class CategoryJpaEntity extends BaseTimeEntity {
 
   private Long thumbnailId;
 
+  @Builder
   public CategoryJpaEntity(Long id, String name, String description, Long thumbnailId,
                            LocalDateTime createdAt, LocalDateTime updatedAt,
                            LocalDateTime deletedAt) {

--- a/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/PerfumeController.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/adapter/in/http/PerfumeController.java
@@ -10,6 +10,9 @@ import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpStatus;
@@ -50,5 +53,12 @@ public class PerfumeController {
     Slice<SimplePerfumeResult> perfumesByBrand = findPerfumeUseCase.findPerfumesByBrand(brandId, lastPerfumeId, pageSize);
     List<SimplePerfumeResponseDto> list = perfumesByBrand.getContent().stream().map(SimplePerfumeResponseDto::of).toList();
     return new SliceImpl<>(list, perfumesByBrand.getPageable(), perfumesByBrand.hasNext());
+  }
+
+  @GetMapping("/category/{id}")
+  public Page<SimplePerfumeResponseDto> getPerfumesByCategory(@PathVariable Long id, Pageable pageable) {
+    Page<SimplePerfumeResult> perfumesByCategory = findPerfumeUseCase.findPerfumesByCategory(id, pageable);
+    List<SimplePerfumeResponseDto> list = perfumesByCategory.getContent().stream().map(SimplePerfumeResponseDto::of).toList();
+    return new PageImpl<>(list, perfumesByCategory.getPageable(), perfumesByCategory.getTotalElements());
   }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/exception/PerfumeNotFoundException.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/exception/PerfumeNotFoundException.java
@@ -5,7 +5,7 @@ import io.perfume.api.base.LogLevel;
 import org.springframework.http.HttpStatus;
 
 public class PerfumeNotFoundException extends CustomHttpException {
-    public PerfumeNotFoundException(Long id) {
-        super(HttpStatus.NOT_FOUND, "cannot find perfume by id: "+id, "cannot find perfume by id: "+id, LogLevel.WARN);
-    }
+  public PerfumeNotFoundException(Long id) {
+    super(HttpStatus.NOT_FOUND, "cannot find perfume by id: " + id, "cannot find perfume by id: " + id, LogLevel.WARN);
+  }
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/FindPerfumeUseCase.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/port/in/FindPerfumeUseCase.java
@@ -11,4 +11,6 @@ public interface FindPerfumeUseCase {
   PerfumeResult findPerfumeById(Long id);
 
   Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize);
+
+  Page<SimplePerfumeResult> findPerfumesByCategory(Long categoryId, Pageable pageable);
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/port/out/PerfumeQueryRepository.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/port/out/PerfumeQueryRepository.java
@@ -4,6 +4,8 @@ import io.perfume.api.perfume.application.port.in.dto.SimplePerfumeResult;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.Perfume;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface PerfumeQueryRepository {
@@ -13,4 +15,6 @@ public interface PerfumeQueryRepository {
   NotePyramid getNotePyramidByPerfume(Long perfumeId);
 
   Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize);
+
+  Page<SimplePerfumeResult> findPerfumesByCategory(Long categoryId, Pageable pageable);
 }

--- a/perfume-api/src/main/java/io/perfume/api/perfume/application/service/FindPerfumeService.java
+++ b/perfume-api/src/main/java/io/perfume/api/perfume/application/service/FindPerfumeService.java
@@ -12,6 +12,8 @@ import io.perfume.api.perfume.application.port.out.PerfumeQueryRepository;
 import io.perfume.api.perfume.domain.NotePyramid;
 import io.perfume.api.perfume.domain.Perfume;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
@@ -37,5 +39,10 @@ public class FindPerfumeService implements FindPerfumeUseCase {
   @Override
   public Slice<SimplePerfumeResult> findPerfumesByBrand(Long brandId, Long lastPerfumeId, int pageSize) {
     return perfumeQueryRepository.findPerfumesByBrand(brandId, lastPerfumeId, pageSize);
+  }
+
+  @Override
+  public Page<SimplePerfumeResult> findPerfumesByCategory(Long categoryId, Pageable pageable) {
+    return perfumeQueryRepository.findPerfumesByCategory(categoryId, pageable);
   }
 }


### PR DESCRIPTION
## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- Issue ticket number: [RDPF-201]
- 카테고리 별로 향수 목록을 페이징하여 가져올 수 있도록 합니다.

## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
-

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 


[RDPF-201]: https://perfumelab.atlassian.net/browse/RDPF-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ