### PR TITLE
fix: 향수 데이터 통계 시 리뷰 없을 때 버그 수정

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/review/application/service/ReviewStatisticService.java
+++ b/perfume-api/src/main/java/io/perfume/api/review/application/service/ReviewStatisticService.java
@@ -4,7 +4,13 @@ import io.perfume.api.review.adapter.out.persistence.repository.ReviewQueryPersi
 import io.perfume.api.review.application.in.ReviewStatisticUseCase;
 import io.perfume.api.review.application.in.dto.ReviewStatisticResult;
 import io.perfume.api.review.domain.ReviewFeatureCount;
+import io.perfume.api.review.domain.type.DayType;
+import io.perfume.api.review.domain.type.Duration;
+import io.perfume.api.review.domain.type.Season;
+import io.perfume.api.review.domain.type.Strength;
+import io.perfume.api.user.adapter.out.persistence.user.Sex;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +29,15 @@ public class ReviewStatisticService implements ReviewStatisticUseCase {
     ReviewFeatureCount reviewFeatureCount = reviewQueryPersistenceAdapter.getReviewFeatureCount(perfumeId);
 
     Long totalReviews = reviewFeatureCount.totalReviews();
+    if (totalReviews == 0) {
+      return new ReviewStatisticResult(
+          createEmptyMap(Strength.class),
+          createEmptyMap(Duration.class),
+          createEmptyMap(Season.class),
+          createEmptyMap(DayType.class),
+          createEmptyMap(Sex.class)
+      );
+    }
     return new ReviewStatisticResult(
         calculatePercentage(reviewFeatureCount.strengthMap(), totalReviews),
         calculatePercentage(reviewFeatureCount.durationMap(), totalReviews),
@@ -32,12 +47,20 @@ public class ReviewStatisticService implements ReviewStatisticUseCase {
     );
   }
 
-  private static <V extends Enum<V>> Map<V, Long> calculatePercentage(Map<V, Long> map, Long totalReviews) {
+  private <V extends Enum<V>> Map<V, Long> calculatePercentage(Map<V, Long> map, Long totalReviews) {
     EnumSet.allOf(map.keySet().iterator().next().getDeclaringClass()).forEach(
         enumValue -> map.putIfAbsent(enumValue, 0L)
     );
 
     return map.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> Math.round((double) e.getValue() / totalReviews * 100)));
+  }
+
+  private <V extends Enum<V>> Map<V, Long> createEmptyMap(Class<V> enumClass) {
+    Map<V, Long> map = new HashMap<>();
+    EnumSet.allOf(enumClass).forEach(
+        enumValue -> map.putIfAbsent(enumValue, 0L)
+    );
+    return map;
   }
 }


### PR DESCRIPTION
## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- Issue ticket number: <!-- 이슈 버전을 작성해주세요. 이후 작업물에 대해 히스토리 파악에 도움이 됩니다. -->

## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
- 기존에 향수에 대한 리뷰가 0개일 때 처리가 되어있지 않아 이부분을 빈 맵을 반환하도록 보완하였습니다.

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [ ] 
