### PR TITLE
refactor: Refactor review request to include perfume name

### DIFF
--- a/perfume-api/src/main/java/io/perfume/api/review/adapter/in/http/dto/CreateReviewRequestDto.java
+++ b/perfume-api/src/main/java/io/perfume/api/review/adapter/in/http/dto/CreateReviewRequestDto.java
@@ -6,14 +6,13 @@ import io.perfume.api.review.domain.type.Duration;
 import io.perfume.api.review.domain.type.Season;
 import io.perfume.api.review.domain.type.Strength;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.hibernate.validator.constraints.Length;
 
 public record CreateReviewRequestDto(
-    @Positive Long perfumeId,
+    Perfume perfume,
     DayType dayType,
     Strength strength,
     Season season,
@@ -25,7 +24,7 @@ public record CreateReviewRequestDto(
 
   public CreateReviewCommand toCommand(LocalDateTime now) {
     return new CreateReviewCommand(
-        perfumeId,
+        perfume.id,
         dayType,
         strength,
         season,
@@ -36,4 +35,6 @@ public record CreateReviewRequestDto(
         Collections.unmodifiableList(keywords),
         now);
   }
+
+  public record Perfume(long id, String name) {}
 }

--- a/perfume-api/src/test/java/io/perfume/api/review/adapter/in/http/ReviewControllerTest.java
+++ b/perfume-api/src/test/java/io/perfume/api/review/adapter/in/http/ReviewControllerTest.java
@@ -82,7 +82,7 @@ class ReviewControllerTest {
     // given
     var dto =
         new CreateReviewRequestDto(
-            1L,
+            new CreateReviewRequestDto.Perfume(1L, "test"),
             DayType.DAILY,
             Strength.LIGHT,
             Season.SPRING,
@@ -105,7 +105,8 @@ class ReviewControllerTest {
             document(
                 "create-review",
                 requestFields(
-                    fieldWithPath("perfumeId").type(JsonFieldType.NUMBER).description("향수 ID"),
+                    fieldWithPath("perfume.id").type(JsonFieldType.NUMBER).description("향수 ID"),
+                    fieldWithPath("perfume.name").type(JsonFieldType.STRING).description("향수 이름"),
                     fieldWithPath("season").type(JsonFieldType.STRING).description("어울리는 계절"),
                     fieldWithPath("dayType").type(JsonFieldType.STRING).description("어울리는 날"),
                     fieldWithPath("strength").type(JsonFieldType.STRING).description("향수 강도"),


### PR DESCRIPTION
The CreateReviewRequestDto object now includes a new `perfume` parameter of the Perfume record type, composed of `id` and `name`. Accordingly, changes were made in the ReviewControllerTest to adapt to the new request structure.

## What is this PR? 👀

<!-- 이 PR에 대해 간단히 설명해주세요. 코드리뷰에 도움이 됩니다. -->

- Issue ticket number: #308  <!-- 이슈 버전을 작성해주세요. 이후 작업물에 대해 히스토리 파악에 도움이 됩니다. -->

## Changes ✏️

<!-- 어떤 변경이 있었는지 알려주세요, 새로운 기능, 수정된 파일 등 코드 파악을 위한 간략한 정보면 좋습니다. -->
- 리뷰 작성 시 향수 정보 추가

## Test checklist 🧪

<!-- 기능 추가 시 작성한 테스트 코드 목록을 작성해주세요. -->

- [x] 향수 작성 API 테스트
